### PR TITLE
Update Minecraft Wiki link to new domain after fork

### DIFF
--- a/utils/mcclient/response.py
+++ b/utils/mcclient/response.py
@@ -45,7 +45,7 @@ class StatusResponse:
         """
         Returns the input string stripped of all Minecraft color/formatting codes.
         documentation on minecraft color/formatting codes:
-        https://minecraft.fandom.com/wiki/Formatting_codes
+        https://minecraft.wiki/w/Formatting_codes
 
         Args:
         cstr (str): The string to remove color codes from.


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom.